### PR TITLE
feat: 소비기한이 지난 재료 필터

### DIFF
--- a/backend/src/main/java/com/shinhan/naengtureat/inventory/InventoryController.java
+++ b/backend/src/main/java/com/shinhan/naengtureat/inventory/InventoryController.java
@@ -77,6 +77,11 @@ public class InventoryController {
 		return ResponseEntity.ok(inventoryService.getInventoriesByKeywordsCategory(keywords, memberId));
 	}
 
+	@GetMapping("/wastebasket")
+	public ResponseEntity<Object> getExpiredInventory() {
+		Long memberId = 1L;
+		return ResponseEntity.ok(inventoryService.getExpiredInventory(memberId));
+	}
 
 	// 식단 재료 - 멤버 보유 재료 목록 조회
 	@GetMapping("/gap")

--- a/backend/src/main/java/com/shinhan/naengtureat/inventory/model/InventoryService.java
+++ b/backend/src/main/java/com/shinhan/naengtureat/inventory/model/InventoryService.java
@@ -4,7 +4,6 @@ package com.shinhan.naengtureat.inventory.model;
 import com.querydsl.core.types.Predicate;
 import com.shinhan.naengtureat.ingredient.dto.IngredientComparisonDTO;
 import com.shinhan.naengtureat.ingredient.entity.Ingredient;
-import com.shinhan.naengtureat.ingredient.model.IngredientRepository;
 import com.shinhan.naengtureat.ingredient.model.IngredientService;
 import com.shinhan.naengtureat.inventory.dto.InventoryRequestDTO;
 import com.shinhan.naengtureat.inventory.dto.InventoryResponseDTO;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;

--- a/backend/src/main/java/com/shinhan/naengtureat/inventory/model/InventoryService.java
+++ b/backend/src/main/java/com/shinhan/naengtureat/inventory/model/InventoryService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -45,27 +46,31 @@ public class InventoryService {
         //남은 기간 계산 및 저장
         setCalculateDday(inventoryResponseDTO);
 
-        //재료 닉네임 저장
-        inventoryResponseDTO.setIngredientName(inventoryResponseDTO.getNickName());
+        //재료 조회
+        Ingredient ingredient = ingredientService.getStandardIngredientById(inventoryResponseDTO.getIngredientId());
+
+        //재료 이름 저장
+        inventoryResponseDTO.setIngredientName(ingredient.getSmallCategory());
         return inventoryResponseDTO;
     }
 
     public List<InventoryResponseDTO> getAllInventory(Long memberId) {
         List<Inventory> inventoryList = inventoryRepository.findAllByMemberId(memberId);
 
-        List<InventoryResponseDTO> inventoryDtos = inventoryList.stream().map((eachInventory) -> {
+        return inventoryList.stream().map((eachInventory) -> {
             //entity -> DTO
             InventoryResponseDTO inventoryResponseDTO = convertDto(eachInventory);
 
             //남은 기간 계산 및 저장
             setCalculateDday(inventoryResponseDTO);
 
-            //재료 닉네임 저장
-            inventoryResponseDTO.setIngredientName(inventoryResponseDTO.getNickName());
+            //재료 조회
+            Ingredient ingredient = ingredientService.getStandardIngredientById(inventoryResponseDTO.getIngredientId());
+
+            //재료 이름 저장
+            inventoryResponseDTO.setIngredientName(ingredient.getSmallCategory());
             return inventoryResponseDTO;
         }).toList();
-
-        return inventoryDtos;
     }
 
     private void setCalculateDday (InventoryResponseDTO inventoryResponseDTO) {
@@ -124,6 +129,26 @@ public class InventoryService {
         List<Inventory> inventoryList = (List<Inventory>) inventoryRepository.findAll(predicate);
 
         return convertDtoList(inventoryList);
+    }
+
+    public List<InventoryResponseDTO> getExpiredInventory(Long memberId) {
+        return inventoryRepository.findAllByMemberId(memberId).stream()
+                .map(eachInventory -> {
+                    //entity -> DTO
+                    InventoryResponseDTO inventoryResponseDTO = convertDto(eachInventory);
+
+                    //남은 기간 계산 및 저장
+                    setCalculateDday(inventoryResponseDTO);
+
+                    //재료 조회
+                    Ingredient ingredient = ingredientService.getStandardIngredientById(inventoryResponseDTO.getIngredientId());
+
+                    //재료 이름 저장
+                    inventoryResponseDTO.setIngredientName(ingredient.getSmallCategory());
+                    return inventoryResponseDTO;
+                })
+                .filter(inventoryResponseDTO -> inventoryResponseDTO.getRemainingDays() < 0)
+                .toList();
     }
 
     public InventoryResponseDTO convertDto(Inventory inventory) {


### PR DESCRIPTION
## 개요
1. 현재 날짜에서 재료의 소비기한 뺸 날짜를 계산한다.
2. 날짜가 음수인 것만 필터링 한다.

Resolves #145

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention](https://www.notion.so/Git-1a10cae5674e813f8c60ebb4a8f99ca4?pvs=4#1aa0cae5674e807aa012d921c8fa6fe4) 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
<img width="1582" alt="image" src="https://github.com/user-attachments/assets/b5a639a7-4268-46e1-8813-34ccadea2733" />
